### PR TITLE
Suppress advice when rebasing drops commits

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -1,3 +1,5 @@
+[advice]
+	skippedCherryPicks = false
 [alias]
 	remotes = remote --verbose
 	who = config user.email


### PR DESCRIPTION
Add advice.skippedCherryPicks = false to Git config