### PR TITLE
Source /etc/bashrc if it exists

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,4 +1,8 @@
+if [[ -f /etc/bashrc ]] then
+  . /etc/bashrc
+fi
+
 # see https://github.com/janmoesen/tilde/blob/master/.bashrc
 if [[ -n ${PS1} ]]; then
-  source ~/.bash_profile;
+  . ~/.bash_profile;
 fi;


### PR DESCRIPTION
If it exists, source `/etc/bashrc` seems to work on macOS as well as Fedora Linux but leaving it in a PR for testing for a while