### PR TITLE
Jump to position 1 in gitcommit files

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -79,6 +79,10 @@ nnoremap <Esc><Esc> :nohlsearch<CR>
 " wrap lines at 80 characters in Markdown files
 autocmd BufRead,BufNewFile *.md setlocal textwidth=80
 
+" vim remembers positions, make sure to always jump to position 1 when editing
+" a git commit message
+autocmd FileType gitcommit :goto 1
+
 " Use Gruvbox colorscheme
 syntax enable
 set background=dark


### PR DESCRIPTION
vim sometimes remembers where the cursor was in a previous commit message and because git prefills .git/COMMIT_EDITMSG this means you will not start on the first line for a brand new commit message.

This change makes sure the cursor for commit messages is always at position 1