### PR TITLE
Update git config

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -15,6 +15,7 @@
 [diff]
 	colorMoved = zebra
 	colorMovedWS = allow-indentation-change
+	mnemonicPrefix = true
 [fetch]
 	fsckObjects = true
 	prune = true


### PR DESCRIPTION
Set `diff.mnemonicPrefix = true` to differentiate the prefixes:

git diff
  compares the (i)ndex and the (w)ork tree;

git diff HEAD
  compares a (c)ommit and the (w)ork tree;

git diff --cached
  compares a (c)ommit and the (i)ndex;

git diff HEAD:file1 file2
  compares an (o)bject and a (w)ork tree entity;

git diff --no-index a b
  compares two non-git things (1) and (2).