### PR TITLE
Add `git root` alias

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -1,8 +1,10 @@
+# vim:noexpandtab
 [advice]
 	detachedHead = false
 	skippedCherryPicks = false
 [alias]
 	remotes = remote --verbose
+	root = rev-parse --show-toplevel
 	who = config user.email
 [commit]
 	verbose = true

--- a/.config/shell/funcs
+++ b/.config/shell/funcs
@@ -8,3 +8,7 @@ dot() {
     export GIT_DIR="$HOME/.dotfiles";
   fi
 }
+
+r() {
+  cd "$(git root)"
+}


### PR DESCRIPTION
`git root` will output the root of the current repository.

Add a function r() to use `git root` to navigate to the root of the current repository.