### PR TITLE
Improve git config includes

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -55,6 +55,6 @@
 	name = matijs
 	useConfigOnly = true
 [includeIf "gitdir:~/.dotfiles"]
-	path = include.d/dotfiles
+	path = ./include.d/dotfiles
 [include]
-	path = keys
+	path = ./keys

--- a/.config/git/include.d/dotfiles
+++ b/.config/git/include.d/dotfiles
@@ -1,4 +1,3 @@
-# This file is only taken into account when the git dir is ~/.git which
-# is only the case in the home dir
+# This file is only taken into account when the git dir is ~/.dotfiles
 [status]
 	showUntrackedFiles = no


### PR DESCRIPTION
Add the relative path to both the `keys` and `dotfiles` includes.

Correct a comment in `include.d/dotfiles`.