### PR TITLE
Set commit.gpgSign = true

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -8,6 +8,7 @@
 	who = config user.email
 	pushf = push --force-with-lease
 [commit]
+	gpgSign = true
 	verbose = true
 [color]
 	diff = always


### PR DESCRIPTION
Always sign commits because it is now easy to sign using SSH keys