### PR TITLE
feat: add editorconfig-vim

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,7 @@
 	path = .vim/pack/_/start/rust.vim
 	url = https://github.com/rust-lang/rust.vim
 	fetchRecurseSubmodules = true
+[submodule ".vim/pack/_/start/editorconfig-vim"]
+	path = .vim/pack/_/start/editorconfig-vim
+	url = https://github.com/matijs/editorconfig-vim.git
+	fetchRecurseSubmodules = true


### PR DESCRIPTION
Add editorconfig-vim as a submodule. The submodule is a fork of editorconfig/editorconfig-vim to make sure cloning dotfiles does not pull in unwanted code.