### PR TITLE
feat: add git autosquash alias

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -3,10 +3,11 @@
 	detachedHead = false
 	skippedCherryPicks = false
 [alias]
+	autosquash = -c sequence.editor=true rebase --interactive
+	pushf = push --force-with-lease
 	remotes = remote --verbose
 	root = rev-parse --show-toplevel
 	who = config user.email
-	pushf = push --force-with-lease
 [commit]
 	gpgSign = true
 	verbose = true


### PR DESCRIPTION
git autosquash <branch>

will autosquash commits made with '--fixup=', '--fixup=amend:', '--fixup=reword:' or '--squash=' without opening GIT_SEQUENCE_EDITOR and immediately having to close it again.