### PR TITLE
feat: fix git config modeline

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -1,4 +1,4 @@
-# vim:noexpandtab
+# vim: noexpandtab filetype=gitconfig
 [advice]
 	detachedHead = false
 	skippedCherryPicks = false


### PR DESCRIPTION
See if GitHub picks up gitconfig as a valid filetype for a file without an extension