### PR TITLE
docs: add modeline

### DIFF
--- a/.config/git/include.d/dotfiles
+++ b/.config/git/include.d/dotfiles
@@ -1,3 +1,5 @@
+# vim: noexpandtab filetype=gitconfig
+
 # This file is only taken into account when the git dir is ~/.dotfiles
 [status]
 	showUntrackedFiles = no


### PR DESCRIPTION
Add modeline to .config/git/include.d/dotfiles

The git configuration in this file is included when working on the files in this repo only