### PR TITLE
feat: always push using ssh

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -60,6 +60,8 @@
 	showUntrackedFiles = all
 [transfer]
 	fsckObjects = true
+[url "git@github.com:"]
+	pushInsteadOf = https://github.com/
 [user]
 	name = matijs
 	useConfigOnly = true


### PR DESCRIPTION
Make sure that cloning/fetching can be done using https:// but pushing always uses ssh://