### PR TITLE
fix: :goto -> goto

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -81,7 +81,7 @@ autocmd BufRead,BufNewFile *.md setlocal textwidth=80
 
 " vim remembers positions, make sure to always jump to position 1 when editing
 " a git commit message
-autocmd FileType gitcommit :goto 1
+autocmd FileType gitcommit goto 1
 " disable vim-editorconfig for git commit messages
 autocmd FileType gitcommit let b:EditorConfig_disable = 1
 


### PR DESCRIPTION
No need for a : in a .vimrc