### PR TITLE
feat(git): add log-no-tags alias

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -4,6 +4,7 @@
 	skippedCherryPicks = false
 [alias]
 	autosquash = -c sequence.editor=true rebase --interactive
+	log-no-tags = log --decorate-refs-exclude=refs/tags
 	pushf = push --force-with-lease
 	remotes = remote --verbose
 	root = rev-parse --show-toplevel


### PR DESCRIPTION
Using `--decorate-refs-exclude=refs/tags` hides tags while still decorating logs normally