### PR TITLE
chore(git): use correct git environment variable

### DIFF
--- a/.config/shell/exports
+++ b/.config/shell/exports
@@ -21,8 +21,7 @@ export LESSHISTFILE='-'
 # - make `less` more colorful: -R
 export LESS='FXR'
 # Tell git never to chdir up into the home directory
-# This makes it possible to have the home directory as a work tree using the default .git as the git dir
-export GIT_CEILING_DIRS="${HOME}"
+export GIT_CEILING_DIRECTORIES="${HOME}"
 
 if [[ $OSTYPE =~ darwin ]]; then
   export LSCOLORS=dxbxbEaEBxxEhEhBaDaCaD;


### PR DESCRIPTION
GIT_CEILING_DIRS did not exist, GIT_CEILING_DIRECTORIES however does.

Remove the comment about using `.git` as GIT_DIR as it is no longer relevant since `.dotfiles` is used instead in the current setup.