### PR TITLE
feat(git): add difft alias for difftastic

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -5,6 +5,7 @@
 	skippedCherryPicks = false
 [alias]
 	autosquash = -c sequence.editor=true rebase --interactive
+	difft = -c diff.external=difft diff
 	log-no-tags = log --decorate-refs-exclude=refs/tags
 	pushf = push --force-with-lease
 	remotes = remote --verbose


### PR DESCRIPTION
Use a combination of "Difftastic By Default" and "Regular Usage" from the [difftastic manual][1] by aliasing "difft" to use a `-c` configuration override for "diff.external" set to "difft"

[1]: https://difftastic.wilfred.me.uk/git.html