### PR TITLE
feat(git): add git fixup alias

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -6,6 +6,7 @@
 [alias]
 	autosquash = -c sequence.editor=true rebase --interactive
 	difft = -c diff.external=difft diff
+	fixup = commit --fixup=HEAD
 	log-no-tags = log --decorate-refs-exclude=refs/tags
 	pushf = push --force-with-lease
 	remotes = remote --verbose


### PR DESCRIPTION
Add a `git fixup` alias for `git commit --fixup=HEAD`

Running `git fixup -a` also works to add all changed files that are already under version control