### PR TITLE
refactor(git): add log.excludeDecoration

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -7,7 +7,6 @@
 	autosquash = -c sequence.editor=true rebase --interactive
 	difft = -c diff.external=difft diff
 	fixup = commit --fixup=HEAD
-	log-no-tags = log --decorate-refs-exclude=refs/tags
 	please = push --force-with-lease
 	pushf = push --force-with-lease
 	remotes = remote --verbose
@@ -40,6 +39,7 @@
 [log]
 	date = iso8601-local
 	decorate = full
+	excludeDecoration = refs/tags
 [merge]
 	conflictStyle = zdiff3
 	ff = only


### PR DESCRIPTION
Remove the alias that was not really working and replace it with a default setting that never shows tags when using `git log`.