### PR TITLE
feat: make Prettier use its config file

### DIFF
--- a/.vim/vimrc
+++ b/.vim/vimrc
@@ -141,3 +141,6 @@ noremap <up> <nop>
 noremap <right> <nop>
 noremap <down> <nop>
 noremap <left> <nop>
+" Make sure vim-prettier makes Prettier use a prettier config file if one is
+" present
+let g:prettier#config#config_precedence = 'prefer-file'


### PR DESCRIPTION
Using vim-prettier seemed to not respect the new default for `trailingComma` which is `"all"` since Prettier 3.0.0

Turns out it was using its own setting `"es5"` instead. Setting the `config_precedence` makes Prettier itself use a config file if it finds one.