### PR TITLE
Improve help.autoCorrect

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -33,7 +33,7 @@
 [gpg]
 	format = ssh
 [help]
-	autoCorrect = 1
+	autoCorrect = prompt
 [init]
 	defaultBranch = main
 [log]


### PR DESCRIPTION
Set `help.autoCorrect` to `prompt` instead of 1. 1 meant 1ms which was too short to do anything and should probably have been `immediate` which is another valid option.

`prompt` was introduced in Git 2.34 so this should work on both macOS as well as Linux.