### PR TITLE
chore: simplify CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
 * @matijs
-.* @matijs


### PR DESCRIPTION
`.*` does override `*` for `.github/CODEOWNERS` but it's not necessary