### PR TITLE
feat(git): detect renames

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -28,6 +28,7 @@
 	colorMoved = zebra
 	colorMovedWS = allow-indentation-change
 	mnemonicPrefix = true
+	renames = copies
 [fetch]
 	fsckObjects = true
 	prune = true


### PR DESCRIPTION
Default is `true` which only enables basic rename detection. Using `copies` (or `copy`) also detects copies.