### PR TITLE
feat(git): show absolute paths in status

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -64,6 +64,7 @@
 [rerere]
 	enabled = true
 [status]
+	relativePaths = false
 	showStash = true
 	showUntrackedFiles = all
 [tag]


### PR DESCRIPTION
Set `status.relativePaths` to `false` to always show absolute paths.