### PR TITLE
feat(git): make whitespace visible in diffs

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -29,6 +29,7 @@
 	colorMovedWS = allow-indentation-change
 	mnemonicPrefix = true
 	renames = copies
+	wsErrorHighlight = all
 [fetch]
 	fsckObjects = true
 	prune = true


### PR DESCRIPTION
Difftastic, which is used when using `git difft` uses an AST to show diffs. This means that when a change consists of only whitespace changes, it will tell the user that there are not syntactic changes.

Just using `git diff` however still works with this new setting and will happily show whitespace changes.