### PR TITLE
feat(tmux): add tmux function

### DIFF
--- a/.config/shell/funcs
+++ b/.config/shell/funcs
@@ -26,3 +26,11 @@ git() {
     command git "$@";
   fi
 }
+
+tmux() {
+  if [[ $# -eq 0 ]]; then
+    command tmux new-session -A -s tmux -n  '~' -c "${HOME}"
+  else
+    command tmux "$@"
+  fi
+}


### PR DESCRIPTION
Add a tmux function that when there are no arguments will start a new session named tmux (`-s`) or re-attach to an existing session named tmux (`-A`), with a single window named ~ (`-n`) in the home dir (`-c`) because I found myself repeating these steps like an animal every single invocation of tmux.

When there are arguments, start tmux with these arguments (`$@`).