### PR TITLE
fix(vim): show relative path

### DIFF
--- a/.vim/vimrc
+++ b/.vim/vimrc
@@ -36,7 +36,7 @@ set modelines=2
 " always (=2) display a status line
 set laststatus=2
 
-set statusline=Buf\ %n\ %F\ %{getbufvar(bufnr('%'),'&mod')?'[mod]':''}\ %{fugitive#statusline()}%r%h%=Ln\ %l/%L,\ Pos\ %o,\ Col\ %c\ %y
+set statusline=Buf\ %n\ %f\ %{getbufvar(bufnr('%'),'&mod')?'[mod]':''}\ %{fugitive#statusline()}%r%h%=Ln\ %l/%L,\ Pos\ %o,\ Col\ %c\ %y
 
 " use 2 spaces for tabs
 set tabstop=2


### PR DESCRIPTION
Instead of showing the absolute path for the buffer, show the relative path that is usually shorter and may fit.