### PR TITLE
chore: improve PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,9 @@
 name: Git checks
 
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - dotfiles
 
 permissions:
   contents: read


### PR DESCRIPTION
Use long form event and only run on pull requests to the "dotfiles" branch.