### PR TITLE
feat: add "github:" shorthand

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -73,6 +73,7 @@
 [transfer]
 	fsckObjects = true
 [url "git@github.com:"]
+	insteadOf = github:
 	pushInsteadOf = https://github.com/
 [user]
 	name = matijs


### PR DESCRIPTION
This makes it possible to clone a repository using:

```sh
git clone github:<username>/<repo>
```