### PR TITLE
Update README.md to set the default branch on init

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -16,7 +16,7 @@ not how it's set up and it's not tested.
 
 ```bash
 ~ $ export GIT_DIR="${HOME}/.dotfiles"
-~ $ git --work-tree="${HOME}" init
+~ $ git --work-tree="${HOME}" -c init.defaultBranch=dotfiles init
 # versions of git before 2.46.0 do not know the `set` subcommand in the command
 # below so leave it out
 ~ $ git config set status.showUntrackedFiles no


### PR DESCRIPTION
Update README.md to set the default branch to `dotfiles` upon initialisation to make git a little less noisy.